### PR TITLE
Fix behaviour when USB stick is disconnected.

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -54,10 +54,16 @@ void Canvas::draw_wireframe()
 
 void Canvas::load_mesh(Mesh* m)
 {
+    if (mesh) {
+        delete mesh;
+    }
     mesh = new GLMesh(m);
 
     QVector3D lower(m->xmin(), m->ymin(), m->zmin());
     QVector3D upper(m->xmax(), m->ymax(), m->zmax());
+
+    delete m;
+
     center = (lower + upper) / 2;
     scale = 2 / (upper - lower).length();
 
@@ -67,8 +73,17 @@ void Canvas::load_mesh(Mesh* m)
     tilt = 90;
 
     update();
+}
 
-    delete m;
+void Canvas::clear()
+{
+    if (mesh) {
+        delete mesh;
+        mesh = nullptr;
+    }
+    status.clear();
+
+    update();
 }
 
 void Canvas::set_status(const QString &s)

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -26,6 +26,7 @@ public slots:
     void set_status(const QString& s);
     void clear_status();
     void load_mesh(Mesh* m);
+    void clear();
 
 protected:
 	void paintGL() override;

--- a/src/selecttab.cpp
+++ b/src/selecttab.cpp
@@ -13,8 +13,6 @@
 
 namespace {
 
-    QString DefaultModelFileName { ":gl/BoundingBox.stl" };
-
     QRegularExpression VolumeLineMatcher { QString { "^volume\\s*=\\s*(\\d+(?:\\.(?:\\d+))?)" }, QRegularExpression::CaseInsensitiveOption };
 
 }
@@ -109,8 +107,6 @@ SelectTab::SelectTab( QWidget* parent ): QWidget( parent ) {
     _layout->setRowStretch( 1, 1 );
 
     setLayout( _layout );
-
-    _loadModel( DefaultModelFileName );
 }
 
 SelectTab::~SelectTab( ) {
@@ -153,7 +149,15 @@ void SelectTab::_lookForUsbStick( QString const& path ) {
     QString dirname { GetFirstDirectoryIn( _userMediaDirectory ) };
     if ( dirname.isEmpty( ) ) {
         debug( "  + no directories in user media directory '%s'\n", _userMediaDirectory.toUtf8( ).data( ) );
-        _showLibrary( );
+        if ( _modelsLocation == ModelsLocation::Usb ) {
+            _showLibrary( );
+        }
+        if ( _fileName.startsWith( _userMediaDirectory ) ) {
+            _fileName.clear( );
+            _canvas->clear( );
+            _dimensionsLabel->clear( );
+            _selectButton->setEnabled( false );
+        }
         _toggleLocationButton->setEnabled( false );
     } else {
         _usbPath = _userMediaDirectory + QString( "/" ) + dirname;


### PR DESCRIPTION
* If we're currently displaying the files on the USB stick, switch back to the model library.
* If a file on the USB stick is currently displayed, clear the canvas (where the model is displayed) and dimensions information, and disable the Select button.
* Fix a memory leak in the canvas class.